### PR TITLE
修复防沉迷不会触发回调的问题

### DIFF
--- a/GodotTDS/GodotTdsPlugin/src/main/java/cc/zhtsu/godot_tds_plugin/tapsdk/Compliance.kt
+++ b/GodotTDS/GodotTdsPlugin/src/main/java/cc/zhtsu/godot_tds_plugin/tapsdk/Compliance.kt
@@ -23,6 +23,7 @@ class Compliance(activity : Activity, godotTdsPlugin: GodotTdsPlugin) : TapTdsIn
         if (_godotTdsPlugin.isLoggedIn())
         {
             val userIdentifier = _godotTdsPlugin.getTapAccount().getAccountOpenId();
+            TapTapCompliance.registerComplianceCallback(_antiComplianceCallback)
             TapTapCompliance.startup(activity = _activity, userId = userIdentifier)
         }
     }


### PR DESCRIPTION
callback需要通过TapTapCompliance.registerComplianceCallback注册